### PR TITLE
Add agent video support

### DIFF
--- a/components/embed-popup/popup-view.tsx
+++ b/components/embed-popup/popup-view.tsx
@@ -17,6 +17,7 @@ import useChatAndTranscription from '@/hooks/use-chat-and-transcription';
 import { useDebugMode } from '@/hooks/useDebug';
 import type { EmbedErrorDetails } from '@/lib/types';
 import { cn } from '@/lib/utils';
+import { AvatarTile } from '../livekit/avatar-tile';
 import { ChatInput } from '../livekit/chat/chat-input';
 
 function isAgentAvailable(agentState: AgentState) {
@@ -37,7 +38,13 @@ export const PopupView = ({
 }: React.ComponentProps<'div'> & SessionViewProps) => {
   const room = useRoomContext();
   const transcriptRef = useRef<HTMLDivElement>(null);
-  const { state: agentState, audioTrack: agentAudioTrack } = useVoiceAssistant();
+  const {
+    state: agentState,
+    audioTrack: agentAudioTrack,
+    videoTrack: agentVideoTrack,
+  } = useVoiceAssistant();
+  const agentHasAvatar = agentVideoTrack !== undefined;
+
   const {
     micTrackRef,
     // FIXME: how do I explicitly ensure only the microphone channel is used?
@@ -165,6 +172,29 @@ export const PopupView = ({
             </AnimatePresence>
           </div>
         </div>
+
+        <motion.div
+          initial={{ opacity: 0, scale: 0 }}
+          variants={{
+            visible: { opacity: 1, scale: 1 },
+            hidden: { opacity: 0, scale: 0 },
+          }}
+          animate={agentHasAvatar ? 'visible' : 'hidden'}
+          exit={{ opacity: 0, scale: 0 }}
+          transition={{
+            type: 'spring',
+            stiffness: 675,
+            damping: 75,
+            mass: 1,
+          }}
+          className={cn('absolute inset-1 h-full overflow-hidden rounded-t-[24px] pb-8', {
+            'pointer-events-none': !agentHasAvatar,
+          })}
+        >
+          {agentVideoTrack ? (
+            <AvatarTile videoTrack={agentVideoTrack} className="h-full object-cover" />
+          ) : null}
+        </motion.div>
 
         <div
           aria-label="Voice assistant controls"

--- a/components/livekit/avatar-tile.tsx
+++ b/components/livekit/avatar-tile.tsx
@@ -1,0 +1,17 @@
+import { type TrackReference, VideoTrack } from '@livekit/components-react';
+
+interface AgentAudioTileProps {
+  videoTrack: TrackReference;
+  className?: string;
+}
+
+export const AvatarTile = ({ videoTrack, className }: AgentAudioTileProps) => {
+  return (
+    <VideoTrack
+      trackRef={videoTrack}
+      width={videoTrack?.publication.dimensions?.width ?? 0}
+      height={videoTrack?.publication.dimensions?.height ?? 0}
+      className={className}
+    />
+  );
+};


### PR DESCRIPTION
Adds agent video support to the popup style embed. Right now the behavior is that if a video track is published by an agent, the video track is shown, covering up the transcriptions. There's no way for now to programmatically switch which one is visible.

> [!NOTE] 
> **Important callout:** I am not totally satisfied yet with the animation when the video is initially shown. It turns out this is kinda a tricky problem to do well because the video track / associated `<video>` element shows up and begins animating in before the video stream has fully initialized, leading to the first half of the animation being in practice hard to see with a dark video background over a dark popup background.

## Demo

<!-- https://github.com/user-attachments/assets/89448991-f4f6-4466-8b8e-70315a076e21 -->

https://github.com/user-attachments/assets/f30a1e1a-df84-4bd4-af2e-c874e08c4fb0

(note - no sound is expected, I didn't capture it as part of the demo)

~## A few other smaller assorted things:~
- ~Fix the message scroll behavior - previously, there was a bug that led to no message scrollback, so users could only see the messages on the screen and that was it.~
- ~Migrate to the pre-existing `agent-starter-react` room connection code - this logic nicely handles enabling the microphone before the room may be fully connected, so a user can start speaking ASAP.~