### PR TITLE
Adjust overlay scrollbar position by changing where padding is applied

### DIFF
--- a/components/embed-popup/popup-view.tsx
+++ b/components/embed-popup/popup-view.tsx
@@ -101,7 +101,7 @@ export const PopupView = ({
 
   return (
     <div ref={ref} inert={disabled} className="flex h-full w-full flex-col overflow-hidden">
-      <div className="relative flex h-full shrink-1 grow-1 flex-col p-1">
+      <div className="relative flex h-full shrink-1 grow-1 flex-col py-1">
         <motion.div
           className={cn(
             'bg-bg2 dark:bg-bg1 pointer-events-none absolute z-10 flex aspect-[1.5] w-64 items-center justify-center rounded-2xl border border-transparent transition-colors',
@@ -147,7 +147,7 @@ export const PopupView = ({
         {/* Transcript */}
         <div
           ref={transcriptRef}
-          className="flex flex-1 flex-col overflow-y-auto [mask-image:linear-gradient(0deg,rgba(0,0,0,0.2)_0%,rgba(0,0,0,1)_5%,rgba(0,0,0,1)_95%,rgba(0,0,0,0)_100%)] py-2"
+          className="flex flex-1 flex-col overflow-y-auto [mask-image:linear-gradient(0deg,rgba(0,0,0,0.2)_0%,rgba(0,0,0,1)_5%,rgba(0,0,0,1)_95%,rgba(0,0,0,0)_100%)] px-1 py-2"
         >
           <div className="flex flex-1 flex-col justify-end gap-2 pt-10">
             <AnimatePresence>
@@ -168,7 +168,7 @@ export const PopupView = ({
 
         <div
           aria-label="Voice assistant controls"
-          className="bg-bg1 border-separator1 relative flex h-12 shrink-0 grow-0 items-center gap-1 rounded-full border px-1 drop-shadow-md"
+          className="bg-bg1 border-separator1 relative mx-1 flex h-12 shrink-0 grow-0 items-center gap-1 rounded-full border px-1 drop-shadow-md"
         >
           <div className="flex gap-1">
             {visibleControls.microphone ? (


### PR DESCRIPTION
Previously, if a user had overlay scrollbars enabled within the embed, the scrollbar was placed in a location that meant there was more scrollbar <-> text overlap than there necessarily needs to be. Example of previous state:

https://github.com/user-attachments/assets/c1321bcd-5762-40c2-8e38-3254fb79e504

With this change applied, the overlay scrollbar is moved further right, reducing the overlap and ensuring text content is fully visible when scrolling:

https://github.com/user-attachments/assets/9ed49db8-cfa5-4a8f-a811-19e65d8db569

I also wanted to note that the existing state has a bit of a weird scroll bar cut off at the top of the embed - I couldn't come up with an obvious mitigation here beyond what was already being done (`overflow: hidden;` applied strategically throughout) so I left it as is.

<img width="83" height="85" alt="Screenshot 2025-09-05 at 9 54 37 AM" src="https://github.com/user-attachments/assets/fd610f3f-9ee9-42b9-9613-56be231f7f88" />

