### PR TITLE
Add popup script to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-starter-app",
+  "name": "agent-starter-embed",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Currently, there is a problem where the published version of this project doesn't see to have a built copy of the embed-popup.js script - see https://agent-starter-embed.production.livekit.io/embed-popup.js, which 404s.

I'm pretty sure this is because the automated vercel build isn't building the script, which must be done out of band given it's a completely different entrypoint with a completely seperate build process from the main next application. So, I've added the separate build command as part of the regular `build` npm script to address this issue.

Note that after with this change, the script now exists in the preview build: https://agent-starter-embed-git-add-popup-script-to-build.staging.livekit.io/embed-popup.js.