### PR TITLE
Add data-sandbox-id attribute to embed script snippet

### DIFF
--- a/app/(app)/popup/page.tsx
+++ b/app/(app)/popup/page.tsx
@@ -1,28 +1,5 @@
-'use client';
+import PopupPageDynamic from '@/components/popup-page-dynamic';
 
-import Script from 'next/script';
-import { HandPointingIcon } from '@phosphor-icons/react';
-import { ThemeToggle } from '@/components/theme-toggle';
-
-export default function PopupPage() {
-  return (
-    <div className="grid min-h-screen place-items-center">
-      <Script src="/embed-popup.js" />
-      <div className="space-y-10">
-        <div className="flex justify-center">
-          <ThemeToggle className="w-fit" />
-        </div>
-        <div className="text-fgAccent flex gap-1">
-          <p className="grow text-sm">
-            The popup button should appear in the bottom right corner of the screen
-          </p>
-          <HandPointingIcon
-            size={16}
-            weight="regular"
-            className="mt-0.5 inline shrink-0 rotate-[145deg] animate-bounce"
-          />
-        </div>
-      </div>
-    </div>
-  );
+export default function Page() {
+  return <PopupPageDynamic />;
 }

--- a/components/embed-popup/standalone-bundle-root.tsx
+++ b/components/embed-popup/standalone-bundle-root.tsx
@@ -7,27 +7,33 @@ import EmbedFixedAgentClient from './agent-client';
 const scriptTag = document.querySelector<HTMLScriptElement>('script[data-lk-sandbox-id]');
 const sandboxIdAttribute = scriptTag?.dataset.lkSandboxId;
 
-const wrapper = document.createElement('div');
-wrapper.setAttribute('id', 'lk-embed-wrapper');
-document.body.appendChild(wrapper);
+if (sandboxIdAttribute) {
+  const wrapper = document.createElement('div');
+  wrapper.setAttribute('id', 'lk-embed-wrapper');
+  document.body.appendChild(wrapper);
 
-// Use a shadow root so that any relevant css classes don't leak out and effect the broader page
-const shadowRoot = wrapper.attachShadow({ mode: 'open' });
+  // Use a shadow root so that any relevant css classes don't leak out and effect the broader page
+  const shadowRoot = wrapper.attachShadow({ mode: 'open' });
 
-// Include all app styles into the shadow root
-// FIXME: this includes styles for the welcome page / etc, not just the popup embed!
-const styleTag = document.createElement('style');
-styleTag.textContent = globalCss;
-shadowRoot.appendChild(styleTag);
+  // Include all app styles into the shadow root
+  // FIXME: this includes styles for the welcome page / etc, not just the popup embed!
+  const styleTag = document.createElement('style');
+  styleTag.textContent = globalCss;
+  shadowRoot.appendChild(styleTag);
 
-const reactRoot = document.createElement('div');
-shadowRoot.appendChild(reactRoot);
+  const reactRoot = document.createElement('div');
+  shadowRoot.appendChild(reactRoot);
 
-getAppConfig(window.location.origin, sandboxIdAttribute)
-  .then((appConfig) => {
-    const root = ReactDOM.createRoot(reactRoot);
-    root.render(<EmbedFixedAgentClient appConfig={appConfig} />);
-  })
-  .catch((err) => {
-    console.error('Error loading livekit embed-popup app config:', err);
-  });
+  getAppConfig(window.location.origin, sandboxIdAttribute)
+    .then((appConfig) => {
+      const root = ReactDOM.createRoot(reactRoot);
+      root.render(<EmbedFixedAgentClient appConfig={appConfig} />);
+    })
+    .catch((err) => {
+      console.error('LiveKit popup embed error - Error loading app config:', err);
+    });
+} else {
+  console.error(
+    'LiveKit popup embed error - no data-lk-sandbox-id attribute found on script tag. This is required!'
+  );
+}

--- a/components/embed-popup/standalone-bundle-root.tsx
+++ b/components/embed-popup/standalone-bundle-root.tsx
@@ -4,6 +4,9 @@ import { getAppConfig } from '@/lib/env';
 import globalCss from '@/styles/globals.css';
 import EmbedFixedAgentClient from './agent-client';
 
+const scriptTag = document.querySelector<HTMLScriptElement>('script[data-lk-sandbox-id]');
+const sandboxIdAttribute = scriptTag?.dataset.lkSandboxId;
+
 const wrapper = document.createElement('div');
 wrapper.setAttribute('id', 'lk-embed-wrapper');
 document.body.appendChild(wrapper);
@@ -20,7 +23,7 @@ shadowRoot.appendChild(styleTag);
 const reactRoot = document.createElement('div');
 shadowRoot.appendChild(reactRoot);
 
-getAppConfig(window.location.origin)
+getAppConfig(window.location.origin, sandboxIdAttribute)
   .then((appConfig) => {
     const root = ReactDOM.createRoot(reactRoot);
     root.render(<EmbedFixedAgentClient appConfig={appConfig} />);

--- a/components/popup-page-dynamic.tsx
+++ b/components/popup-page-dynamic.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+export default dynamic(() => import('./popup-page'), { ssr: false });

--- a/components/popup-page.tsx
+++ b/components/popup-page.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useMemo } from 'react';
+import Script from 'next/script';
+import { HandPointingIcon } from '@phosphor-icons/react';
+import { ThemeToggle } from '@/components/theme-toggle';
+import { getSandboxId } from '@/lib/env';
+
+export default function PopupPage() {
+  const sandboxId = useMemo(() => getSandboxId(window.location.origin), []);
+  return (
+    <div className="grid min-h-screen place-items-center">
+      <Script src="/embed-popup.js" data-lk-sandbox-id={sandboxId} />
+      <div className="space-y-10">
+        <div className="flex justify-center">
+          <ThemeToggle className="w-fit" />
+        </div>
+        <div className="text-fgAccent flex gap-1">
+          <p className="grow text-sm">
+            The popup button should appear in the bottom right corner of the screen
+          </p>
+          <HandPointingIcon
+            size={16}
+            weight="regular"
+            className="mt-0.5 inline shrink-0 rotate-[145deg] animate-bounce"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/welcome.tsx
+++ b/components/welcome.tsx
@@ -5,7 +5,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { motion } from 'motion/react';
 import { CheckIcon, CopyIcon, HandPointingIcon } from '@phosphor-icons/react';
 import { APP_CONFIG_DEFAULTS } from '@/app-config';
-import { THEME_STORAGE_KEY } from '@/lib/env';
+import { THEME_STORAGE_KEY, getSandboxId } from '@/lib/env';
 import type { ThemeMode } from '@/lib/types';
 import { cn } from '@/lib/utils';
 import EmbedPopupAgentClient from './embed-popup/agent-client';
@@ -42,9 +42,11 @@ export default function Welcome() {
     return url.toString();
   }, []);
 
+  const embedSandboxId = useMemo(() => getSandboxId(window.location.origin), []);
+
   const popupEmbedCode = useMemo(
-    () => `<script\n  src="${popupEmbedUrl}"\n></script>`,
-    [popupEmbedUrl]
+    () => `<script\n  src="${popupEmbedUrl}"\n  data-lk-sandbox-id="${embedSandboxId}"\n></script>`,
+    [popupEmbedUrl, embedSandboxId]
   );
   const iframeEmbedCode = useMemo(() => {
     return `<iframe\n  src="${iframeEmbedUrl}"\n  style="width: 320px; height: 64px;"\n></iframe>`;
@@ -165,13 +167,8 @@ export default function Welcome() {
             <h3 className="sr-only text-lg font-semibold">Popup Style</h3>
             <div>
               <h4 className="text-fg0 mb-1 font-semibold">Embed code</h4>
-              <pre className="border-separator2 bg-bg2 relative overflow-auto rounded-md border px-2 py-1">
+              <pre className="border-separator2 bg-bg2 overflow-auto rounded-md border px-2 py-1">
                 <code className="font-mono">{popupEmbedCode}</code>
-                <div className="absolute top-0 right-0">
-                  <Button onClick={() => copyEmbedCode(popupEmbedCode)}>
-                    {copied ? <CheckIcon className="text-fgSuccess" /> : <CopyIcon />}
-                  </Button>
-                </div>
               </pre>
               <p className="text-fg4 my-4 text-sm">
                 To apply local changes, run{' '}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -14,38 +14,44 @@ export function getOrigin(headers: Headers): string {
   return `${proto}://${host}`;
 }
 
+export function getSandboxId(origin: string) {
+  return SANDBOX_ID ?? origin.split('.')[0];
+}
+
 // https://react.dev/reference/react/cache#caveats
 // > React will invalidate the cache for all memoized functions for each server request.
-export const getAppConfig = cache(async (origin: string): Promise<AppConfig> => {
-  if (CONFIG_ENDPOINT) {
-    const sandboxId = SANDBOX_ID ?? origin.split('.')[0];
+export const getAppConfig = cache(
+  async (origin: string, sandboxIdAttribute?: string): Promise<AppConfig> => {
+    if (CONFIG_ENDPOINT) {
+      const sandboxId = sandboxIdAttribute ?? getSandboxId(origin);
 
-    try {
-      const response = await fetch(CONFIG_ENDPOINT, {
-        cache: 'no-store',
-        headers: { 'X-Sandbox-ID': sandboxId },
-      });
+      try {
+        const response = await fetch(CONFIG_ENDPOINT, {
+          cache: 'no-store',
+          headers: { 'X-Sandbox-ID': sandboxId },
+        });
 
-      const remoteConfig: SandboxConfig = await response.json();
-      const config: AppConfig = { ...APP_CONFIG_DEFAULTS };
+        const remoteConfig: SandboxConfig = await response.json();
+        const config: AppConfig = { ...APP_CONFIG_DEFAULTS };
 
-      for (const [key, entry] of Object.entries(remoteConfig)) {
-        if (entry === null) continue;
-        if (
-          key in config &&
-          typeof config[key as keyof AppConfig] === entry.type &&
-          typeof config[key as keyof AppConfig] === typeof entry.value
-        ) {
-          // @ts-expect-error I'm not sure quite how to appease TypeScript, but we've thoroughly checked types above
-          config[key as keyof AppConfig] = entry.value as AppConfig[keyof AppConfig];
+        for (const [key, entry] of Object.entries(remoteConfig)) {
+          if (entry === null) continue;
+          if (
+            key in config &&
+            typeof config[key as keyof AppConfig] === entry.type &&
+            typeof config[key as keyof AppConfig] === typeof entry.value
+          ) {
+            // @ts-expect-error I'm not sure quite how to appease TypeScript, but we've thoroughly checked types above
+            config[key as keyof AppConfig] = entry.value as AppConfig[keyof AppConfig];
+          }
         }
+
+        return config;
+      } catch (error) {
+        console.error('!!!', error);
       }
-
-      return config;
-    } catch (error) {
-      console.error('!!!', error);
     }
-  }
 
-  return APP_CONFIG_DEFAULTS;
-});
+    return APP_CONFIG_DEFAULTS;
+  }
+);


### PR DESCRIPTION
Previously, the generated embed popup script didn't work properly because it might be loaded on an origin where the sandbox id couldn't be extracted from the url or be otherwise located. This meant that while this repository could be demo'd effectively, you couldn't really in practice use the script tag popup embed outside of the sandbox web app origin.

This change introduces a new `data-lk-sandbox-id` attribute which can be specified on the script tag that loads the popup.
```html
<script
  src="http://localhost:3002/embed-popup.js"
  data-lk-sandbox-id="sandboxidhere"
></script>
```

Now,  _this_ sandbox id is used when talking to the sandbox token server endpoint to get a token rather than attempting to extract it from the URL or anything like that. This now means that an embed popup script can be added to any page and it should always work because the sandbox id is now being included as part of the embed!