### PR TITLE
Fix sandbox ID handling for popup and iframe variants

### DIFF
--- a/app/(iframe)/embed/page.tsx
+++ b/app/(iframe)/embed/page.tsx
@@ -6,7 +6,8 @@ import { getAppConfig, getOrigin } from '@/lib/env';
 export default async function Embed() {
   const hdrs = await headers();
   const origin = getOrigin(hdrs);
-  const appConfig = await getAppConfig(origin);
+  const sandboxId = hdrs.get('x-sandbox-id');
+  const appConfig = await getAppConfig(origin, sandboxId ?? undefined);
 
   return (
     <>

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -32,7 +32,7 @@ export const getAppConfig = cache(
         });
 
         const remoteConfig: SandboxConfig = await response.json();
-        const config: AppConfig = { ...APP_CONFIG_DEFAULTS };
+        const config: AppConfig = { ...APP_CONFIG_DEFAULTS, sandboxId };
 
         for (const [key, entry] of Object.entries(remoteConfig)) {
           if (entry === null) continue;

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -15,7 +15,9 @@ export function getOrigin(headers: Headers): string {
 }
 
 export function getSandboxId(origin: string) {
-  return SANDBOX_ID ?? origin.split('.')[0];
+  if (SANDBOX_ID) return SANDBOX_ID;
+  const host = origin.replace(/^https?:\/\//, '');
+  return host.split('.')[0];
 }
 
 // https://react.dev/reference/react/cache#caveats


### PR DESCRIPTION
Fixes three bugs in how the embed app resolves and propagates the sandbox ID, affecting both the popup and iframe variants.

**1. Popup — sandboxId not on returned AppConfig**
`getAppConfig()` received the sandbox ID as a parameter and used it to fetch remote config, but never included it on the returned `AppConfig` object. This caused the popup variant's connection-details request to send an empty `X-Sandbox-Id` header, resulting in a 400 from cloud-api-server since it couldn't identify the sandbox from the host page's origin (e.g., `localhost`).

**2. Iframe — protocol prefix in getSandboxId**
`getSandboxId()` splits the origin on `.` to extract the subdomain, but the origin includes the protocol (e.g., `https://my-sandbox.sandbox.livekit.io`). This produced `https://my-sandbox` instead of `my-sandbox`, causing the config fetch to fail for self-hosted deployments that don't use the Cloudflare router.

**3. Iframe — host header changed by Cloudflare router**
When the Cloudflare sandbox router proxies requests, the `host` header becomes the backend app's hostname, not the original sandbox hostname. The iframe page now reads the `x-sandbox-id` header that the router sets on every proxied request, and passes it directly to `getAppConfig()`. Self-hosted deployments without the router fall back to `getSandboxId()` which parses the origin.

Resolves GRW-324