### PR TITLE
Consume dynamic styling, logos, and text from app config

### DIFF
--- a/app-config.ts
+++ b/app-config.ts
@@ -7,4 +7,10 @@ export const APP_CONFIG_DEFAULTS: AppConfig = {
   supportsVideoInput: true,
   supportsScreenShare: true,
   isPreConnectBufferEnabled: true,
+  startButtonText: 'Chat with Agent',
+  companyName: 'LiveKit',
+  accent: '#1fd5f9',
+  accentDark: '#002cf2',
+  logo: '/lk-logo.svg',
+  logoDark: '/lk-logo-dark.svg',
 };

--- a/app/(iframe)/embed/page.tsx
+++ b/app/(iframe)/embed/page.tsx
@@ -2,16 +2,19 @@ import { headers } from 'next/headers';
 import EmbedAgentClient from '@/components/embed-iframe/agent-client';
 import { ApplyThemeScript } from '@/components/embed-iframe/theme-provider';
 import { getAppConfig, getOrigin } from '@/lib/env';
+import { getStyles } from '@/lib/styles';
 
 export default async function Embed() {
   const hdrs = await headers();
   const origin = getOrigin(hdrs);
   const sandboxId = hdrs.get('x-sandbox-id');
   const appConfig = await getAppConfig(origin, sandboxId ?? undefined);
+  const styles = getStyles(appConfig);
 
   return (
     <>
       <ApplyThemeScript />
+      {styles && <style dangerouslySetInnerHTML={{ __html: styles }} />}
       <EmbedAgentClient appConfig={appConfig} />
     </>
   );

--- a/components/embed-iframe/agent-client.tsx
+++ b/components/embed-iframe/agent-client.tsx
@@ -107,9 +107,17 @@ function EmbedAgentClient({ appConfig }: AppProps) {
         <div className="flex h-full items-center justify-between gap-1 gap-4 pl-3">
           <div className="pl-3">
             {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src={appConfig.logo ?? '/lk-logo.svg'} alt={`${appConfig.companyName ?? 'LiveKit'} Logo`} className="block size-6 dark:hidden" />
+            <img
+              src={appConfig.logo ?? '/lk-logo.svg'}
+              alt={`${appConfig.companyName ?? 'LiveKit'} Logo`}
+              className="block size-6 dark:hidden"
+            />
             {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src={appConfig.logoDark ?? '/lk-logo-dark.svg'} alt={`${appConfig.companyName ?? 'LiveKit'} Logo`} className="hidden size-6 dark:block" />
+            <img
+              src={appConfig.logoDark ?? '/lk-logo-dark.svg'}
+              alt={`${appConfig.companyName ?? 'LiveKit'} Logo`}
+              className="hidden size-6 dark:block"
+            />
           </div>
 
           <div className="flex flex-col justify-center">

--- a/components/embed-iframe/agent-client.tsx
+++ b/components/embed-iframe/agent-client.tsx
@@ -81,6 +81,7 @@ function EmbedAgentClient({ appConfig }: AppProps) {
     <div className="bg-background relative h-16 rounded-full border px-3">
       <MotionWelcomeView
         key="welcome"
+        appConfig={appConfig}
         onStartCall={() => setSessionStarted(true)}
         disabled={sessionStarted}
         initial={{ opacity: 1 }}
@@ -106,9 +107,9 @@ function EmbedAgentClient({ appConfig }: AppProps) {
         <div className="flex h-full items-center justify-between gap-1 gap-4 pl-3">
           <div className="pl-3">
             {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src="/lk-logo.svg" alt="LiveKit Logo" className="block size-6 dark:hidden" />
+            <img src={appConfig.logo ?? '/lk-logo.svg'} alt={`${appConfig.companyName ?? 'LiveKit'} Logo`} className="block size-6 dark:hidden" />
             {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src="/lk-logo-dark.svg" alt="LiveKit Logo" className="hidden size-6 dark:block" />
+            <img src={appConfig.logoDark ?? '/lk-logo-dark.svg'} alt={`${appConfig.companyName ?? 'LiveKit'} Logo`} className="hidden size-6 dark:block" />
           </div>
 
           <div className="flex flex-col justify-center">

--- a/components/embed-iframe/welcome-view.tsx
+++ b/components/embed-iframe/welcome-view.tsx
@@ -1,27 +1,34 @@
 import { Button } from '@/components/ui/button';
+import type { AppConfig } from '@/lib/types';
 
 type WelcomeViewProps = {
+  appConfig: AppConfig;
   disabled: boolean;
   onStartCall: () => void;
 };
 
 export const WelcomeView = ({
+  appConfig,
   disabled,
   onStartCall,
   ref,
 }: React.ComponentProps<'div'> & WelcomeViewProps) => {
+  const logo = appConfig.logo ?? '/lk-logo.svg';
+  const logoDark = appConfig.logoDark ?? '/lk-logo-dark.svg';
+  const companyName = appConfig.companyName ?? 'LiveKit';
+
   return (
     <div ref={ref} inert={disabled} className="absolute inset-0">
       <div className="flex h-full items-center justify-between gap-4 px-3">
         <div className="pl-3">
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src="/lk-logo.svg" alt="LiveKit Logo" className="block size-6 dark:hidden" />
+          <img src={logo} alt={`${companyName} Logo`} className="block size-6 dark:hidden" />
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src="/lk-logo-dark.svg" alt="LiveKit Logo" className="hidden size-6 dark:block" />
+          <img src={logoDark} alt={`${companyName} Logo`} className="hidden size-6 dark:block" />
         </div>
 
         <Button variant="primary" size="lg" onClick={onStartCall} className="w-48 font-mono">
-          Chat with Agent
+          {appConfig.startButtonText ?? 'Chat with Agent'}
         </Button>
       </div>
     </div>

--- a/components/embed-popup/agent-client.tsx
+++ b/components/embed-popup/agent-client.tsx
@@ -112,7 +112,12 @@ function AgentClient({ appConfig }: EmbedFixedAgentClientProps) {
       <RoomAudioRenderer />
       <StartAudio label="Start Audio" />
 
-      <Trigger appConfig={appConfig} error={error} popupOpen={popupOpen} onToggle={handleTogglePopup} />
+      <Trigger
+        appConfig={appConfig}
+        error={error}
+        popupOpen={popupOpen}
+        onToggle={handleTogglePopup}
+      />
 
       <motion.div
         inert={!popupOpen}

--- a/components/embed-popup/agent-client.tsx
+++ b/components/embed-popup/agent-client.tsx
@@ -112,7 +112,7 @@ function AgentClient({ appConfig }: EmbedFixedAgentClientProps) {
       <RoomAudioRenderer />
       <StartAudio label="Start Audio" />
 
-      <Trigger error={error} popupOpen={popupOpen} onToggle={handleTogglePopup} />
+      <Trigger appConfig={appConfig} error={error} popupOpen={popupOpen} onToggle={handleTogglePopup} />
 
       <motion.div
         inert={!popupOpen}
@@ -135,7 +135,7 @@ function AgentClient({ appConfig }: EmbedFixedAgentClientProps) {
       >
         <div className="bg-bg1 dark:bg-bg2 border-separator1 dark:border-separator2 ml-auto h-[480px] w-full rounded-[28px] border border-solid drop-shadow-md md:w-[360px]">
           <div className="relative h-full w-full">
-            <ErrorMessage error={error} />
+            <ErrorMessage appConfig={appConfig} error={error} />
             {!error && (
               <PopupViewMotion
                 appConfig={appConfig}

--- a/components/embed-popup/error-message.tsx
+++ b/components/embed-popup/error-message.tsx
@@ -1,11 +1,17 @@
+import type { AppConfig } from '@/lib/types';
 import { EmbedErrorDetails } from '@/lib/types';
 import { cn } from '@/lib/utils';
 
 interface ErrorMessageProps {
+  appConfig: AppConfig;
   error: EmbedErrorDetails | null;
 }
 
-export function ErrorMessage({ error }: ErrorMessageProps) {
+export function ErrorMessage({ appConfig, error }: ErrorMessageProps) {
+  const logo = appConfig.logo ?? '/lk-logo.svg';
+  const logoDark = appConfig.logoDark ?? '/lk-logo-dark.svg';
+  const companyName = appConfig.companyName ?? 'LiveKit';
+
   return (
     <div
       inert={error === null}
@@ -16,9 +22,9 @@ export function ErrorMessage({ error }: ErrorMessageProps) {
     >
       <div className="pl-3">
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src="/lk-logo.svg" alt="LiveKit Logo" className="block size-6 dark:hidden" />
+        <img src={logo} alt={`${companyName} Logo`} className="block size-6 dark:hidden" />
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src="/lk-logo-dark.svg" alt="LiveKit Logo" className="hidden size-6 dark:block" />
+        <img src={logoDark} alt={`${companyName} Logo`} className="hidden size-6 dark:block" />
       </div>
 
       <div className="flex w-full flex-col justify-center gap-4 overflow-auto px-8 text-center">

--- a/components/embed-popup/standalone-bundle-root.tsx
+++ b/components/embed-popup/standalone-bundle-root.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import ReactDOM from 'react-dom/client';
 import { getAppConfig } from '@/lib/env';
+import { getStyles } from '@/lib/styles';
 import globalCss from '@/styles/globals.css';
 import EmbedFixedAgentClient from './agent-client';
 
@@ -26,6 +27,14 @@ if (sandboxIdAttribute) {
 
   getAppConfig(window.location.origin, sandboxIdAttribute)
     .then((appConfig) => {
+      // Inject dynamic accent color overrides into the shadow root
+      const dynamicStyles = getStyles(appConfig);
+      if (dynamicStyles) {
+        const dynamicStyleTag = document.createElement('style');
+        dynamicStyleTag.textContent = dynamicStyles;
+        shadowRoot.appendChild(dynamicStyleTag);
+      }
+
       const root = ReactDOM.createRoot(reactRoot);
       root.render(<EmbedFixedAgentClient appConfig={appConfig} />);
     })

--- a/components/embed-popup/trigger.tsx
+++ b/components/embed-popup/trigger.tsx
@@ -1,6 +1,7 @@
 import { AnimatePresence, motion } from 'motion/react';
 import { useVoiceAssistant } from '@livekit/components-react';
 import { PhoneDisconnectIcon, XIcon } from '@phosphor-icons/react';
+import type { AppConfig } from '@/lib/types';
 import { EmbedErrorDetails } from '@/lib/types';
 import { cn } from '@/lib/utils';
 import { Button } from '../ui/button';
@@ -8,12 +9,13 @@ import { Button } from '../ui/button';
 const AnimatedButton = motion.create(Button);
 
 interface TriggerProps {
+  appConfig: AppConfig;
   error: EmbedErrorDetails | null;
   popupOpen: boolean;
   onToggle: () => void;
 }
 
-export function Trigger({ error = null, popupOpen, onToggle }: TriggerProps) {
+export function Trigger({ appConfig, error = null, popupOpen, onToggle }: TriggerProps) {
   const { state: agentState } = useVoiceAssistant();
 
   const isAgentConnecting =
@@ -82,7 +84,7 @@ export function Trigger({ error = null, popupOpen, onToggle }: TriggerProps) {
                   className="bg-bg1 size-5"
                   // webpack build throws if I use custom tailwind classes to achive this
                   style={{
-                    maskImage: 'url(/lk-logo.svg)',
+                    maskImage: `url(${appConfig.logo ?? '/lk-logo.svg'})`,
                     maskSize: 'contain',
                   }}
                 />

--- a/lib/styles.ts
+++ b/lib/styles.ts
@@ -1,0 +1,20 @@
+import type { AppConfig } from './types';
+
+/**
+ * Generate inline CSS that overrides accent color variables from app config.
+ * Follows the same pattern as agent-starter-react.
+ */
+export function getStyles(appConfig: AppConfig): string {
+  const { accent, accentDark } = appConfig;
+
+  return [
+    accent
+      ? `:root { --primary: ${accent}; --primary-hover: color-mix(in srgb, ${accent} 80%, #000); --fgAccent: ${accent}; }`
+      : '',
+    accentDark
+      ? `.dark { --primary: ${accentDark}; --primary-hover: color-mix(in srgb, ${accentDark} 80%, #000); --fgAccent: ${accentDark}; }`
+      : '',
+  ]
+    .filter(Boolean)
+    .join('\n');
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -15,6 +15,13 @@ export interface AppConfig {
   supportsVideoInput: boolean;
   supportsScreenShare: boolean;
   isPreConnectBufferEnabled: boolean;
+
+  startButtonText?: string;
+  companyName?: string;
+  accent?: string;
+  accentDark?: string;
+  logo?: string;
+  logoDark?: string;
 }
 
 export interface SandboxConfig {


### PR DESCRIPTION
Adds support for dynamic accent colors, logos, company name, and button text from the sandbox app-config endpoint. Follows the same pattern as agent-starter-react.

**Config type expansion:**
- Added `accent`, `accentDark`, `logo`, `logoDark`, `companyName`, `startButtonText` to `AppConfig`
- Defaults match the existing hardcoded values so self-hosted deployments are unchanged

**Dynamic theming:**
- New `getStyles()` utility generates CSS custom property overrides for `--primary`, `--primary-hover`, and `--fgAccent`
- Iframe: injected in the embed page layout
- Popup: injected into the shadow DOM after config loads

**Dynamic logos and text:**
- All hardcoded `/lk-logo.svg` references replaced with `appConfig.logo` (with fallback)
- "Chat with Agent" button text reads from `appConfig.startButtonText`
- Logo alt text uses `appConfig.companyName`
- Updated across both iframe and popup variants: welcome-view, agent-client error state, popup trigger, popup error-message

Depends on livekit-examples/index#37 for the template input schema that drives the dashboard config form.

Resolves GRW-325