### PR TITLE
Fix empty string fallbacks and popup shadow DOM styling

### DIFF
--- a/app-config.ts
+++ b/app-config.ts
@@ -9,8 +9,8 @@ export const APP_CONFIG_DEFAULTS: AppConfig = {
   isPreConnectBufferEnabled: true,
   startButtonText: 'Chat with Agent',
   companyName: 'LiveKit',
-  accent: '#1fd5f9',
-  accentDark: '#002cf2',
+  accent: '#002cf2',
+  accentDark: '#1fd5f9',
   logo: '/lk-logo.svg',
   logoDark: '/lk-logo-dark.svg',
 };

--- a/components/embed-iframe/agent-client.tsx
+++ b/components/embed-iframe/agent-client.tsx
@@ -108,14 +108,14 @@ function EmbedAgentClient({ appConfig }: AppProps) {
           <div className="pl-3">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
-              src={appConfig.logo ?? '/lk-logo.svg'}
-              alt={`${appConfig.companyName ?? 'LiveKit'} Logo`}
+              src={appConfig.logo || '/lk-logo.svg'}
+              alt={`${appConfig.companyName || 'LiveKit'} Logo`}
               className="block size-6 dark:hidden"
             />
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
-              src={appConfig.logoDark ?? '/lk-logo-dark.svg'}
-              alt={`${appConfig.companyName ?? 'LiveKit'} Logo`}
+              src={appConfig.logoDark || '/lk-logo-dark.svg'}
+              alt={`${appConfig.companyName || 'LiveKit'} Logo`}
               className="hidden size-6 dark:block"
             />
           </div>

--- a/components/embed-iframe/welcome-view.tsx
+++ b/components/embed-iframe/welcome-view.tsx
@@ -13,9 +13,9 @@ export const WelcomeView = ({
   onStartCall,
   ref,
 }: React.ComponentProps<'div'> & WelcomeViewProps) => {
-  const logo = appConfig.logo ?? '/lk-logo.svg';
-  const logoDark = appConfig.logoDark ?? '/lk-logo-dark.svg';
-  const companyName = appConfig.companyName ?? 'LiveKit';
+  const logo = appConfig.logo || '/lk-logo.svg';
+  const logoDark = appConfig.logoDark || '/lk-logo-dark.svg';
+  const companyName = appConfig.companyName || 'LiveKit';
 
   return (
     <div ref={ref} inert={disabled} className="absolute inset-0">
@@ -28,7 +28,7 @@ export const WelcomeView = ({
         </div>
 
         <Button variant="primary" size="lg" onClick={onStartCall} className="w-48 font-mono">
-          {appConfig.startButtonText ?? 'Chat with Agent'}
+          {appConfig.startButtonText || 'Chat with Agent'}
         </Button>
       </div>
     </div>

--- a/components/embed-popup/error-message.tsx
+++ b/components/embed-popup/error-message.tsx
@@ -8,9 +8,9 @@ interface ErrorMessageProps {
 }
 
 export function ErrorMessage({ appConfig, error }: ErrorMessageProps) {
-  const logo = appConfig.logo ?? '/lk-logo.svg';
-  const logoDark = appConfig.logoDark ?? '/lk-logo-dark.svg';
-  const companyName = appConfig.companyName ?? 'LiveKit';
+  const logo = appConfig.logo || '/lk-logo.svg';
+  const logoDark = appConfig.logoDark || '/lk-logo-dark.svg';
+  const companyName = appConfig.companyName || 'LiveKit';
 
   return (
     <div

--- a/components/embed-popup/standalone-bundle-root.tsx
+++ b/components/embed-popup/standalone-bundle-root.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import ReactDOM from 'react-dom/client';
 import { getAppConfig } from '@/lib/env';
-import { getStyles } from '@/lib/styles';
+import { getShadowStyles } from '@/lib/styles';
 import globalCss from '@/styles/globals.css';
 import EmbedFixedAgentClient from './agent-client';
 
@@ -28,7 +28,7 @@ if (sandboxIdAttribute) {
   getAppConfig(window.location.origin, sandboxIdAttribute)
     .then((appConfig) => {
       // Inject dynamic accent color overrides into the shadow root
-      const dynamicStyles = getStyles(appConfig);
+      const dynamicStyles = getShadowStyles(appConfig);
       if (dynamicStyles) {
         const dynamicStyleTag = document.createElement('style');
         dynamicStyleTag.textContent = dynamicStyles;

--- a/components/embed-popup/trigger.tsx
+++ b/components/embed-popup/trigger.tsx
@@ -80,14 +80,24 @@ export function Trigger({ appConfig, error = null, popupOpen, onToggle }: Trigge
                 exit={{ opacity: 0, y: popupOpen ? 20 : -20 }}
                 className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
               >
-                <div
-                  className="bg-bg1 size-5"
-                  // webpack build throws if I use custom tailwind classes to achive this
-                  style={{
-                    maskImage: `url(${appConfig.logo ?? '/lk-logo.svg'})`,
-                    maskSize: 'contain',
-                  }}
-                />
+                {appConfig.logo ? (
+                  // Custom logo: render as <img> to preserve original colors
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={appConfig.logo}
+                    alt={`${appConfig.companyName || 'LiveKit'}`}
+                    className="size-5 rounded-sm object-contain"
+                  />
+                ) : (
+                  // Default LiveKit mark: use CSS mask for single-color treatment
+                  <div
+                    className="bg-bg1 size-5"
+                    style={{
+                      maskImage: 'url(/lk-logo.svg)',
+                      maskSize: 'contain',
+                    }}
+                  />
+                )}
               </motion.div>
             )}
             {(isAgentConnecting || (error && popupOpen)) && (

--- a/lib/styles.ts
+++ b/lib/styles.ts
@@ -3,9 +3,13 @@ import type { AppConfig } from './types';
 /**
  * Generate inline CSS that overrides accent color variables from app config.
  * Follows the same pattern as agent-starter-react.
+ *
+ * Uses :root/.dark for iframe (full document) context.
+ * Use getShadowStyles() for popup (shadow DOM) context.
  */
 export function getStyles(appConfig: AppConfig): string {
-  const { accent, accentDark } = appConfig;
+  const accent = appConfig.accent || undefined;
+  const accentDark = appConfig.accentDark || undefined;
 
   return [
     accent
@@ -13,6 +17,27 @@ export function getStyles(appConfig: AppConfig): string {
       : '',
     accentDark
       ? `.dark { --primary: ${accentDark}; --primary-hover: color-mix(in srgb, ${accentDark} 80%, #000); --fgAccent: ${accentDark}; }`
+      : '',
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+/**
+ * Generate inline CSS for use inside a shadow DOM.
+ * Uses :host instead of :root since :root targets the document element,
+ * not the shadow host.
+ */
+export function getShadowStyles(appConfig: AppConfig): string {
+  const accent = appConfig.accent || undefined;
+  const accentDark = appConfig.accentDark || undefined;
+
+  return [
+    accent
+      ? `:host { --primary: ${accent}; --primary-hover: color-mix(in srgb, ${accent} 80%, #000); --fgAccent: ${accent}; }`
+      : '',
+    accentDark
+      ? `:host(.dark) { --primary: ${accentDark}; --primary-hover: color-mix(in srgb, ${accentDark} 80%, #000); --fgAccent: ${accentDark}; }`
       : '',
   ]
     .filter(Boolean)


### PR DESCRIPTION
Empty config values (e.g., clearing a logo URL field) produced broken images because ?? doesn't catch empty strings. Changed all config fallbacks from ?? to || so empty strings fall back to defaults.

Added getShadowStyles() for the popup variant. The popup runs inside a shadow DOM where :root targets the document element, not the shadow host. The new function uses :host/:host(.dark) selectors so accent color overrides apply correctly within the shadow DOM context.